### PR TITLE
fix: support loading transactions in EagerSnapshot

### DIFF
--- a/crates/core/src/kernel/snapshot/log_segment.rs
+++ b/crates/core/src/kernel/snapshot/log_segment.rs
@@ -30,9 +30,10 @@ lazy_static! {
     pub(super) static ref COMMIT_SCHEMA: StructType = StructType::new(vec![
         ActionType::Add.schema_field().clone(),
         ActionType::Remove.schema_field().clone(),
+        ActionType::Txn.schema_field().clone(),
     ]);
     pub(super) static ref CHECKPOINT_SCHEMA: StructType =
-        StructType::new(vec![ActionType::Add.schema_field().clone(),]);
+        StructType::new(vec![ActionType::Add.schema_field().clone(), ActionType::Txn.schema_field().clone(),]);
     pub(super) static ref TOMBSTONE_SCHEMA: StructType =
         StructType::new(vec![ActionType::Remove.schema_field().clone(),]);
 }

--- a/crates/core/src/kernel/snapshot/replay.rs
+++ b/crates/core/src/kernel/snapshot/replay.rs
@@ -264,8 +264,6 @@ impl LogReplayScanner {
             }
         }
 
-        dbg!(&txns);
-
         Ok(txns)
     }
 

--- a/crates/core/src/kernel/snapshot/serde.rs
+++ b/crates/core/src/kernel/snapshot/serde.rs
@@ -125,6 +125,7 @@ impl Serialize for EagerSnapshot {
     {
         let mut seq = serializer.serialize_seq(None)?;
         seq.serialize_element(&self.snapshot)?;
+        seq.serialize_element(&self.transactions)?;
         for batch in self.files.iter() {
             let mut buffer = vec![];
             let mut writer = FileWriter::try_new(&mut buffer, batch.schema().as_ref())
@@ -156,6 +157,9 @@ impl<'de> Visitor<'de> for EagerSnapshotVisitor {
         let snapshot = seq
             .next_element()?
             .ok_or_else(|| de::Error::invalid_length(0, &self))?;
+        let transactions = seq
+            .next_element()?
+            .ok_or_else(|| de::Error::invalid_length(1, &self))?;
         let mut files = Vec::new();
         while let Some(elem) = seq.next_element::<Vec<u8>>()? {
             let mut reader =
@@ -170,7 +174,7 @@ impl<'de> Visitor<'de> for EagerSnapshotVisitor {
                 })?;
             files.push(rb);
         }
-        Ok(EagerSnapshot { snapshot, files })
+        Ok(EagerSnapshot { snapshot, files, transactions })
     }
 }
 

--- a/crates/core/src/operations/transaction/mod.rs
+++ b/crates/core/src/operations/transaction/mod.rs
@@ -602,10 +602,7 @@ impl<'a> PostCommit<'a> {
             } else {
                 snapshot.advance(vec![&self.data])?;
             }
-            let state = DeltaTableState {
-                app_transaction_version: HashMap::new(),
-                snapshot,
-            };
+            let state = DeltaTableState { snapshot };
             // Execute each hook
             if self.create_checkpoint {
                 self.create_checkpoint(&state, &self.log_store, self.version)

--- a/crates/core/src/table/state.rs
+++ b/crates/core/src/table/state.rs
@@ -25,7 +25,6 @@ use crate::{DeltaResult, DeltaTableError};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DeltaTableState {
-    pub(crate) app_transaction_version: HashMap<String, i64>,
     pub(crate) snapshot: EagerSnapshot,
 }
 
@@ -38,10 +37,7 @@ impl DeltaTableState {
         version: Option<i64>,
     ) -> DeltaResult<Self> {
         let snapshot = EagerSnapshot::try_new(table_root, store.clone(), config, version).await?;
-        Ok(Self {
-            snapshot,
-            app_transaction_version: HashMap::new(),
-        })
+        Ok(Self { snapshot })
     }
 
     /// Return table version
@@ -89,7 +85,6 @@ impl DeltaTableState {
 
         let snapshot = EagerSnapshot::new_test(&commit_data).unwrap();
         Ok(Self {
-            app_transaction_version: Default::default(),
             snapshot,
         })
     }
@@ -158,7 +153,7 @@ impl DeltaTableState {
     /// HashMap containing the last txn version stored for every app id writing txn
     /// actions.
     pub fn app_transaction_version(&self) -> &HashMap<String, i64> {
-        &self.app_transaction_version
+        &self.snapshot.transactions()
     }
 
     /// The most recent protocol of the table.

--- a/crates/core/tests/transactions.rs
+++ b/crates/core/tests/transactions.rs
@@ -1,0 +1,133 @@
+use std::collections::HashMap;
+
+use deltalake_core::{checkpoints::create_checkpoint_for, kernel::{Action, EagerSnapshot, Txn}, logstore::LogStoreRef, operations::transaction::{CommitBuilder, FinalizedCommit, TableReference}, protocol::DeltaOperation, DeltaTableConfig};
+use deltalake_test::{utils::{LocalStorageIntegration, TestTables}, IntegrationContext};
+use object_store::path::Path;
+
+async fn assert_txn(log_store: LogStoreRef, old_snapshot: &mut EagerSnapshot, commit: &FinalizedCommit, expected: HashMap<String, i64>) {
+    // Assert snapshot captured during commit is accurate, this uses snapshot.advance
+    let new_snapshot = commit.snapshot();
+    let txns = new_snapshot.app_transaction_version();
+    assert_eq!(txns, &expected);
+
+    // Assert updating snapshot via update, loads transactions
+    old_snapshot.update(log_store.clone(), None).await.unwrap();
+    let txns = old_snapshot.transactions();
+    assert_eq!(txns, &expected);
+    
+    // Reload snapshot from store and assert transactions
+    let new_snapshot = EagerSnapshot::try_new(&Path::default(), log_store.object_store(), DeltaTableConfig::default(), None).await.unwrap();
+    let txns = new_snapshot.transactions();
+    assert_eq!(txns, &expected);
+}
+
+#[tokio::test]
+async fn test_transaction_write_read() {
+    let context = IntegrationContext::new(Box::<LocalStorageIntegration>::default()).unwrap();
+    context.load_table(TestTables::Simple).await.unwrap();
+    let log_store = context.table_builder(TestTables::Simple).build_storage().unwrap();
+    let store = log_store.object_store();
+
+    let mut old_snapshot = EagerSnapshot::try_new(&Path::default(), store.clone(), DeltaTableConfig::default(), None).await.unwrap();
+    let txns = old_snapshot.transactions();
+    assert_eq!(txns.len(), 0);
+
+    let commit = CommitBuilder::default().with_actions(vec![
+        Action::Txn(Txn {
+            app_id: "test".to_string(),
+            version: 11,
+            ..Default::default()
+        })
+    ]).build(Some(&old_snapshot as &dyn TableReference), log_store.clone(), DeltaOperation::Update { predicate: None }).unwrap().await.unwrap();
+    
+    assert_txn(log_store.clone(), &mut old_snapshot, &commit, [("test".to_string(), 11)].into_iter().collect()).await;
+}
+
+#[tokio::test]
+async fn test_transaction_multiple() {
+    let context = IntegrationContext::new(Box::<LocalStorageIntegration>::default()).unwrap();
+    context.load_table(TestTables::Simple).await.unwrap();
+    let log_store = context.table_builder(TestTables::Simple).build_storage().unwrap();
+    let store = log_store.object_store();
+
+    let mut old_snapshot = EagerSnapshot::try_new(&Path::default(), store.clone(), DeltaTableConfig::default(), None).await.unwrap();
+    let txns = old_snapshot.transactions();
+    assert_eq!(txns.len(), 0);
+
+    let commit = CommitBuilder::default().with_actions(vec![
+        Action::Txn(Txn {
+            app_id: "test".to_string(),
+            version: 11,
+            ..Default::default()
+        })
+    ]).build(Some(&old_snapshot as &dyn TableReference), log_store.clone(), DeltaOperation::Update { predicate: None }).unwrap().await.unwrap();
+    
+    assert_txn(log_store.clone(), &mut old_snapshot, &commit, [("test".to_string(), 11)].into_iter().collect()).await;
+
+    let mut old_snapshot = EagerSnapshot::try_new(&Path::default(), store.clone(), DeltaTableConfig::default(), None).await.unwrap();
+    let commit = CommitBuilder::default().with_actions(vec![
+        Action::Txn(Txn {
+            app_id: "test".to_string(),
+            version: 10,
+            ..Default::default()
+        }),
+        Action::Txn(Txn {
+            app_id: "test1".to_string(),
+            version: 10,
+            ..Default::default()
+        }),
+    ]).build(Some(&old_snapshot as &dyn TableReference), log_store.clone(), DeltaOperation::Update { predicate: None }).unwrap().await.unwrap();
+
+    assert_txn(log_store.clone(), &mut old_snapshot, &commit, [("test".to_string(), 10), ("test1".to_string(), 10)].into_iter().collect()).await;
+}
+
+#[tokio::test]
+async fn test_transaction_from_checkpoint() {
+    let context = IntegrationContext::new(Box::<LocalStorageIntegration>::default()).unwrap();
+    context.load_table(TestTables::Simple).await.unwrap();
+    let log_store = context.table_builder(TestTables::Simple).build_storage().unwrap();
+    let store = log_store.object_store();
+
+    let mut old_snapshot = EagerSnapshot::try_new(&Path::default(), store.clone(), DeltaTableConfig::default(), None).await.unwrap();
+    let txns = old_snapshot.transactions();
+    assert_eq!(txns.len(), 0);
+
+    let commit = CommitBuilder::default().with_actions(vec![
+        Action::Txn(Txn {
+            app_id: "test".to_string(),
+            version: 11,
+            ..Default::default()
+        })
+    ]).build(Some(&old_snapshot as &dyn TableReference), log_store.clone(), DeltaOperation::Update { predicate: None }).unwrap().await.unwrap();
+    
+    assert_txn(log_store.clone(), &mut old_snapshot, &commit, [("test".to_string(), 11)].into_iter().collect()).await;
+
+    create_checkpoint_for(commit.version, &commit.snapshot, log_store.as_ref()).await.unwrap();
+    let new_snapshot = EagerSnapshot::try_new(&Path::default(), store.clone(), DeltaTableConfig::default(), None).await.unwrap();
+    let txns = new_snapshot.transactions();
+    assert_eq!(txns.len(), 1);
+    assert_eq!(txns.get("test"), Some(&11));
+
+    let mut old_snapshot = EagerSnapshot::try_new(&Path::default(), store.clone(), DeltaTableConfig::default(), None).await.unwrap();
+    let commit = CommitBuilder::default().with_actions(vec![
+        Action::Txn(Txn {
+            app_id: "test".to_string(),
+            version: 10,
+            ..Default::default()
+        }),
+        Action::Txn(Txn {
+            app_id: "test1".to_string(),
+            version: 10,
+            ..Default::default()
+        }),
+    ]).build(Some(&old_snapshot as &dyn TableReference), log_store.clone(), DeltaOperation::Update { predicate: None }).unwrap().await.unwrap();
+
+    assert_txn(log_store.clone(), &mut old_snapshot, &commit, [("test".to_string(), 10), ("test1".to_string(), 10)].into_iter().collect()).await;
+
+    create_checkpoint_for(commit.version, &commit.snapshot, log_store.as_ref()).await.unwrap();
+    let new_snapshot = EagerSnapshot::try_new(&Path::default(), store.clone(), DeltaTableConfig::default(), None).await.unwrap();
+    let txns = new_snapshot.transactions();
+    assert_eq!(txns.len(), 2);
+    assert_eq!(txns.get("test"), Some(&10));
+    assert_eq!(txns.get("test1"), Some(&10));
+}


### PR DESCRIPTION
When EagerSnapshot is created, transaction actions are also loaded.

The implementation is similar to what will be coming to v0.18 from upstream: https://github.com/delta-io/delta-rs/pull/2539/files