### PR TITLE
Backtick structfield support

### DIFF
--- a/crates/core/src/kernel/snapshot/mod.rs
+++ b/crates/core/src/kernel/snapshot/mod.rs
@@ -21,10 +21,12 @@ use std::sync::Arc;
 
 use ::serde::{Deserialize, Serialize};
 use arrow_array::RecordBatch;
+use datafusion_functions::string::ends_with;
 use futures::stream::BoxStream;
 use futures::{StreamExt, TryStreamExt};
 use object_store::path::Path;
 use object_store::ObjectStore;
+use tracing::field::debug;
 
 use self::log_segment::{LogSegment, PathExt};
 use self::parse::{read_adds, read_removes};
@@ -315,7 +317,7 @@ impl Snapshot {
         let stats_fields = if let Some(stats_cols) = self.table_config().stats_columns() {
             stats_cols
                 .iter()
-                .map(|col| match schema.field(col) {
+                .map(|col| match get_stats_field(schema, col) {
                     Some(field) => match field.data_type() {
                         DataType::Map(_) | DataType::Array(_) | &DataType::BINARY => {
                             Err(DeltaTableError::Generic(format!(
@@ -738,6 +740,36 @@ mod datafusion {
     }
 }
 
+/// Checks if provided string is enclosed in char_to_remove and extracts the enclosed string.
+/// If the string is not enclosed, it returns the original string.
+fn extract_enclosed_string(string_to_extract: &str, enclosing_char: char) -> &str {
+    if string_to_extract.len() > 1
+        && string_to_extract.starts_with(enclosing_char)
+        && string_to_extract.ends_with(enclosing_char)
+    {
+        &string_to_extract[1..string_to_extract.len() - 1]
+    } else {
+        string_to_extract
+    }
+}
+
+/// Retrieves a specific field from the schema based on the provided field name.
+/// It handles cases where the field name is nested or enclosed in backticks.
+fn get_stats_field<'a>(schema: &'a StructType, stats_field_name: &str) -> Option<&'a StructField> {
+    match stats_field_name.split_once('.') {
+        Some((parent, children)) => {
+            let parent_field = schema.fields.get(extract_enclosed_string(parent, '`'))?;
+            match parent_field.data_type() {
+                DataType::Struct(inner) => get_stats_field(inner.as_ref(), children),
+                _ => None,
+            }
+        }
+        None => schema
+            .fields
+            .get(extract_enclosed_string(stats_field_name, '`')),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
@@ -955,5 +987,61 @@ mod tests {
             .all(|(_, add)| { new_files.contains(&add.path) }));
 
         Ok(())
+    }
+
+    #[test]
+    fn test_field_with_name() {
+        let schema = StructType::new(vec![
+            StructField::new("a", DataType::STRING, true),
+            StructField::new("b", DataType::INTEGER, true),
+        ]);
+        let field = get_stats_field(&schema, "b").unwrap();
+        assert_eq!(*field, StructField::new("b", DataType::INTEGER, true));
+    }
+
+    #[test]
+    fn test_field_with_name_nested() {
+        let nested = StructType::new(vec![StructField::new(
+            "nested_struct",
+            DataType::BOOLEAN,
+            true,
+        )]);
+        let schema = StructType::new(vec![
+            StructField::new("a", DataType::STRING, true),
+            StructField::new("b", DataType::Struct(Box::new(nested)), true),
+        ]);
+
+        let field = get_stats_field(&schema, "b.nested_struct").unwrap();
+
+        assert_eq!(
+            *field,
+            StructField::new("nested_struct", DataType::BOOLEAN, true)
+        );
+    }
+
+    #[test]
+    fn test_field_with_last_name_nested_backticks() {
+        let nested = StructType::new(vec![StructField::new("pr!me", DataType::BOOLEAN, true)]);
+        let schema = StructType::new(vec![
+            StructField::new("a", DataType::STRING, true),
+            StructField::new("b", DataType::Struct(Box::new(nested)), true),
+        ]);
+
+        let field = get_stats_field(&schema, "b.`pr!me`").unwrap();
+
+        assert_eq!(*field, StructField::new("pr!me", DataType::BOOLEAN, true));
+    }
+
+    #[test]
+    fn test_field_with_name_nested_backticks() {
+        let nested = StructType::new(vec![StructField::new("pr", DataType::BOOLEAN, true)]);
+        let schema = StructType::new(vec![
+            StructField::new("a", DataType::STRING, true),
+            StructField::new("b&b", DataType::Struct(Box::new(nested)), true),
+        ]);
+
+        let field = get_stats_field(&schema, "`b&b`.pr").unwrap();
+
+        assert_eq!(*field, StructField::new("pr", DataType::BOOLEAN, true));
     }
 }

--- a/crates/core/src/kernel/snapshot/mod.rs
+++ b/crates/core/src/kernel/snapshot/mod.rs
@@ -21,12 +21,10 @@ use std::sync::Arc;
 
 use ::serde::{Deserialize, Serialize};
 use arrow_array::RecordBatch;
-use datafusion_functions::string::ends_with;
 use futures::stream::BoxStream;
 use futures::{StreamExt, TryStreamExt};
 use object_store::path::Path;
 use object_store::ObjectStore;
-use tracing::field::debug;
 
 use self::log_segment::{LogSegment, PathExt};
 use self::parse::{read_adds, read_removes};


### PR DESCRIPTION
# Description
Added column parsing to include nested columns and `` enclosing to adopt 0.18.x

# Addressing issue
#2572  
https://github.com/delta-io/delta/blob/4b102d34a2ce881b2a851b4c6cfbf2ab3ab5534f/spark/src/main/scala/org/apache/spark/sql/delta/DeltaConfig.scala#L549-L561

# Changes:
## Added:
_extract_enclosed_string_ - is a utility function to remove enclosing characters from a string.
_get_stats_field_ - is a function to retrieve a field from a schema, handling nested field names and removing enclosing backticks.